### PR TITLE
Removed `KUBE_HOST` env variable, uses kubernetes built in config loader for outside cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,8 @@ outside the scope of this example.
 # Building and Running
 
 If you're testing this outside of Kubernetes, you can just use `go build` followed by
-`KUBE_HOST=... ./k8s-router`.  If you're building this to run on Kubernetes, you'll need to do the following:
+`./k8s-router` to run in mock mode. Will detect Kubernetes cluster config based on kube config.
+If you're building this to run on Kubernetes, you'll need to do the following:
 
 * `CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o k8s-router .`
 * `docker build ...`
@@ -498,8 +499,7 @@ example DaemonSet for deploying the k8s-router as an ingress controller to Kuber
 * `kubectl create -f examples/ingress-daemonset.yaml`
 
 **Note:** This router is written to be ran within Kubernetes but for testing purposes, it can be ran outside of
-Kubernetes.  When ran outside of Kubernetes, you will have to set the `KUBE_HOST` environment variable to point to the
-Kubernetes API.  _(Example: `http://192.168.64.2:8080`)_  When ran outside the container, nginx itself will not be
+Kubernetes.  When ran outside of Kubernetes, you will have have a kube config file. When ran outside the container, nginx itself will not be
 started and its configuration file will not be written to disk, only printed to stdout.  This might change in the future
 but for now, this support is only as a convenience.
 

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"os"
 	"testing"
 )
 
@@ -29,20 +28,8 @@ const (
 Test for github.com/30x/k8s-router/kubernetes/client#GetClient
 */
 func TestGetClient(t *testing.T) {
-	os.Unsetenv("KUBE_HOST")
-
+	// Test will need proper kube config, dosen't need to be reachable
 	client, err := GetClient()
-
-	if client != nil {
-		t.Fatal("Client should be nil when KUBE_HOST is not set")
-	} else if err.Error() != ErrNeedsKubeHostSet {
-		t.Fatalf(ErrUnexpected, err)
-	}
-
-	// The value does not matter because creating a client does not validate the k8s server
-	os.Setenv("KUBE_HOST", "http://192.168.64.2:8080")
-
-	client, err = GetClient()
 
 	if err != nil {
 		t.Fatalf(ErrUnexpected, err)

--- a/main.go
+++ b/main.go
@@ -106,8 +106,8 @@ configure this, please review the design document located here:
 
 https://github.com/30x/k8s-router#design
 
-This application is written to run inside the Kubernetes cluster but for outside of Kubernetes you can set the
-`KUBE_HOST` environment variable to run in a mock mode.
+This application is written to run inside the Kubernetes cluster but for outside if a proper kube config is detected. Will
+run in mock as a result.
 */
 func main() {
 	log.Println("Starting the Kubernetes Router")
@@ -136,6 +136,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v.", err)
 	}
+
+	// Don't write nginx conf when not in cluster
+	nginx.RunInMockMode = !(kubernetes.RunningInCluster())
 
 	// Start nginx with the default configuration to start nginx as a daemon
 	nginx.StartServer(nginx.GetDefaultConf(config))

--- a/nginx/server.go
+++ b/nginx/server.go
@@ -24,9 +24,11 @@ import (
 	"os/exec"
 )
 
+// If running locally enabled mock mode to not call sh commands or write config
+var RunInMockMode bool
+
 func shellOut(cmd string, exitOnFailure bool) {
-	// If we are running outside of Kubenetes, KUBE_HOST will be set in which case we do not want to start nginx
-	if os.Getenv("KUBE_HOST") != "" {
+	if RunInMockMode {
 		return
 	}
 
@@ -46,17 +48,18 @@ func shellOut(cmd string, exitOnFailure bool) {
 func writeNginxConf(conf string) {
 	log.Println(conf)
 
-	// If we are running outside of Kuberenetes, KUBE_HOST will be set in which case we do not want to write nginx.conf
-	if os.Getenv("KUBE_HOST") == "" {
-		// Create the nginx.conf file based on the template
-		if w, err := os.Create(NginxConfPath); err != nil {
-			log.Fatalf("Failed to open %s: %v", NginxConfPath, err)
-		} else if _, err := io.WriteString(w, conf); err != nil {
-			log.Fatalf("Failed to write template %v", err)
-		}
-
-		log.Printf("Wrote nginx configuration to %s\n", NginxConfPath)
+	if RunInMockMode {
+		return;
 	}
+
+	// Create the nginx.conf file based on the template
+	if w, err := os.Create(NginxConfPath); err != nil {
+		log.Fatalf("Failed to open %s: %v", NginxConfPath, err)
+	} else if _, err := io.WriteString(w, conf); err != nil {
+		log.Fatalf("Failed to write template %v", err)
+	}
+
+	log.Printf("Wrote nginx configuration to %s\n", NginxConfPath)
 }
 
 /*


### PR DESCRIPTION
Implements #45.

No longer looks at `KUBE_HOST` if not in cluster will try to load local kube config.