### PR TITLE
Improved internal caching

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func initController(config *router.Config, kubeClient *client.Client) (*router.C
 	// Create a cache to keep track of the router "API Keys" and Pods (with routes)
 	cache := &router.Cache{
 		Pods:    make(map[string]*router.PodWithRoutes),
-		Secrets: make(map[string]*api.Secret),
+		Secrets: make(map[string][]byte),
 	}
 
 	// Turn the pods into a map based on the pod's name
@@ -61,7 +61,7 @@ func initController(config *router.Config, kubeClient *client.Client) (*router.C
 
 	// Turn the secrets into a map based on the secret's namespace
 	for i, secret := range secrets.Items {
-		cache.Secrets[secret.Namespace] = &(secrets.Items[i])
+		cache.Secrets[secret.Namespace] = router.ConvertSecretToModel(config, &(secrets.Items[i]))
 	}
 
 	log.Printf("  Secrets found: %d", len(secrets.Items))

--- a/main.go
+++ b/main.go
@@ -49,10 +49,7 @@ func initController(config *router.Config, kubeClient *client.Client) (*router.C
 
 	// Turn the pods into a map based on the pod's name
 	for i, pod := range pods.Items {
-		cache.Pods[pod.Name] = &router.PodWithRoutes{
-			Pod:    &(pods.Items[i]),
-			Routes: router.GetRoutes(config, &pod),
-		}
+		cache.Pods[pod.Name] = router.ConvertPodToModel(config, &(pods.Items[i]));
 	}
 
 	// Query the initial list of Secrets

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -28,8 +28,6 @@ import (
 	"text/template"
 
 	"github.com/30x/k8s-router/router"
-
-	"k8s.io/kubernetes/pkg/api"
 )
 
 const (
@@ -127,7 +125,7 @@ type locationT struct {
 
 type serverT struct {
 	IsUpstream bool
-	Pod        *api.Pod
+	Pod        *router.PodWithRoutes
 	Target     string
 }
 
@@ -226,7 +224,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 			}
 
 			var locationSecret string
-			namespace := cacheEntry.Pod.Namespace
+			namespace := cacheEntry.Namespace
 			secret, ok := cache.Secrets[namespace]
 
 			if ok {
@@ -266,7 +264,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 						// If there is no server for this target, create one
 						if ok {
 							upstream.Servers = append(upstream.Servers, &serverT{
-								Pod:    cacheEntry.Pod,
+								Pod:    cacheEntry,
 								Target: target,
 							})
 
@@ -282,7 +280,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 							Servers: []*serverT{
 								location.Server,
 								&serverT{
-									Pod:    cacheEntry.Pod,
+									Pod:    cacheEntry,
 									Target: target,
 								},
 							},
@@ -301,7 +299,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 					Path:      route.Incoming.Path,
 					Secret:    locationSecret,
 					Server: &serverT{
-						Pod:    cacheEntry.Pod,
+						Pod:    cacheEntry,
 						Target: target,
 					},
 				}

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -229,7 +229,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 
 			if ok {
 				// There is guaranteed to be an API Key so no need to double check
-				locationSecret = base64.StdEncoding.EncodeToString(secret.Data[config.APIKeySecretDataField])
+				locationSecret = base64.StdEncoding.EncodeToString(secret)
 			}
 
 			location, ok := host.Locations[route.Incoming.Path]

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -71,7 +71,7 @@ func resetConf() {
 func validateConf(t *testing.T, desc, expected string, pods []*api.Pod, secrets []*api.Secret) {
 	cache := &router.Cache{
 		Pods:    make(map[string]*router.PodWithRoutes),
-		Secrets: make(map[string]*api.Secret),
+		Secrets: make(map[string][]byte),
 	}
 
 	for _, pod := range pods {
@@ -79,7 +79,7 @@ func validateConf(t *testing.T, desc, expected string, pods []*api.Pod, secrets 
 	}
 
 	for _, secret := range secrets {
-		cache.Secrets[secret.Namespace] = secret
+		cache.Secrets[secret.Namespace] = router.ConvertSecretToModel(config, secret)
 	}
 
 	actual := GetConf(config, cache)

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -75,10 +75,7 @@ func validateConf(t *testing.T, desc, expected string, pods []*api.Pod, secrets 
 	}
 
 	for _, pod := range pods {
-		cache.Pods[pod.Name] = &router.PodWithRoutes{
-			Pod:    pod,
-			Routes: router.GetRoutes(config, pod),
-		}
+		cache.Pods[pod.Name] = router.ConvertPodToModel(config, pod)
 	}
 
 	for _, secret := range secrets {

--- a/router/pods.go
+++ b/router/pods.go
@@ -98,6 +98,9 @@ func GetRoutablePodList(config *Config, kubeClient *client.Client) (*api.PodList
 }
 
 
+/*
+ Calculate hash for hosts and paths annotations to compare when pod is modified
+*/
 func calculateAnnotationHash(config *Config, pod *api.Pod) (uint64) {
 	h := fnv.New64()
 	h.Write([]byte(pod.Annotations[config.HostsAnnotation]))

--- a/router/secrets_test.go
+++ b/router/secrets_test.go
@@ -62,7 +62,7 @@ Test for github.com/30x/k8s-router/router/secrets#UpdateSecretCacheForEvents
 func TestUpdateSecretCacheForEvents(t *testing.T) {
 	apiKeyStr := "API-Key"
 	apiKey := []byte(apiKeyStr)
-	cache := make(map[string]*api.Secret)
+	cache := make(map[string][]byte)
 	namespace := "my-namespace"
 
 	addedSecret := &api.Secret{
@@ -132,7 +132,7 @@ func TestUpdateSecretCacheForEvents(t *testing.T) {
 		t.Fatal("Server should require a restart")
 	}
 
-	if apiKeyStr == string(cache[namespace].Data[config.APIKeySecretDataField][:]) {
+	if apiKeyStr == string(cache[namespace][:]) {
 		t.Fatal("Cache should have the updated secret")
 	}
 

--- a/router/types.go
+++ b/router/types.go
@@ -26,7 +26,7 @@ Cache is the structure containing the router API Keys and the routable pods cach
 */
 type Cache struct {
 	Pods    map[string]*PodWithRoutes
-	Secrets map[string]*api.Secret
+	Secrets map[string][]byte
 }
 
 /*

--- a/router/types.go
+++ b/router/types.go
@@ -69,7 +69,10 @@ type Outgoing struct {
 PodWithRoutes contains a pod and its routes
 */
 type PodWithRoutes struct {
-	Pod    *api.Pod
+	Name string
+	Namespace string
+	Status api.PodPhase
+	AnnotationHash uint64
 	Routes []*Route
 }
 


### PR DESCRIPTION
Implements #44 

Instead of storing the pointer to Kubernete's v1.Pod structure and v1.Secret structure in the cache and thus holding onto the full object. This PR converts that struct to our model with only things we use in nginx/config and router/pods.

For secrets the cache is now just a lookup of namespace to the byte array of the token.

For pods we store Namespace, Pod Status, and a fnv hash of the annotations used for quick comparison when a pod is checked during an update event.
