### PR TITLE
Increase client request body size to 100m

### DIFF
--- a/nginx/config.go
+++ b/nginx/config.go
@@ -57,7 +57,7 @@ daemon on;
   server_names_hash_bucket_size 64;
 
   # Maximum body size in request
-  client_max_body_size 100m;
+  client_max_body_size {{.Config.ClientMaxBodySize}};
 
   # Force HTTP 1.1 for upstream requests
   proxy_http_version 1.1;
@@ -139,6 +139,7 @@ type templateDataT struct {
 	Hosts        map[string]*hostT
 	Port         int
 	Upstreams    map[string]*upstreamT
+	Config *router.Config
 }
 
 type upstreamT struct {
@@ -210,6 +211,7 @@ func GetConf(config *router.Config, cache *router.Cache) string {
 		Hosts:        make(map[string]*hostT),
 		Port:         config.Port,
 		Upstreams:    make(map[string]*upstreamT),
+		Config: config,
 	}
 
 	// Process the pods to populate the nginx configuration data structure

--- a/nginx/config.go
+++ b/nginx/config.go
@@ -56,6 +56,9 @@ daemon on;
   server_names_hash_max_size 512;
   server_names_hash_bucket_size 64;
 
+  # Maximum body size in request
+  client_max_body_size 100m;
+
   # Force HTTP 1.1 for upstream requests
   proxy_http_version 1.1;
 

--- a/router/config.go
+++ b/router/config.go
@@ -45,6 +45,8 @@ const (
 	DefaultPort = 80
 	// DefaultRoutableLabelSelector is the default value for EnvVarRoutableLabelSelector (routable=true)
 	DefaultRoutableLabelSelector = "routable=true"
+	// Default ClientMaxBodySize for nginx max client request size. Default 100mb
+	DefaultClientMaxBodySize = "100m"
 	// EnvVarAPIKeyHeader Environment variable name for providing the header name used to identify the API Key header
 	EnvVarAPIKeyHeader = "API_KEY_HEADER"
 	// EnvVarAPIKeySecretLocation Environment variable name for providing the location of the secret (name:field) to identify API Key secrets
@@ -55,6 +57,8 @@ const (
 	EnvVarPathsAnnotation = "PATHS_ANNOTATION"
 	// EnvVarPort Environment variable for providing the port nginx should listen on
 	EnvVarPort = "PORT"
+	// EnvClientMaxBodySize Environment variable for max client request body size
+	EnvClientMaxBodySize = "CLIENT_MAX_BODY_SIZE"
 	// EnvVarRoutableLabelSelector Environment variable name for providing the label selector for identifying routable objects
 	EnvVarRoutableLabelSelector = "ROUTABLE_LABEL_SELECTOR"
 	// ErrMsgTmplInvalidAnnotationName is the error message template for an invalid annotation name
@@ -75,6 +79,7 @@ func ConfigFromEnv() (*Config, error) {
 		APIKeyHeader:    os.Getenv(EnvVarAPIKeyHeader),
 		HostsAnnotation: os.Getenv(EnvVarHostsAnnotation),
 		PathsAnnotation: os.Getenv(EnvVarPathsAnnotation),
+		ClientMaxBodySize: os.Getenv(EnvClientMaxBodySize),
 	}
 
 	// Apply defaults
@@ -88,6 +93,10 @@ func ConfigFromEnv() (*Config, error) {
 
 	if config.PathsAnnotation == "" {
 		config.PathsAnnotation = DefaultPathsAnnotation
+	}
+
+	if config.ClientMaxBodySize == "" {
+		config.ClientMaxBodySize = DefaultClientMaxBodySize
 	}
 
 	// Validate configuration

--- a/router/types.go
+++ b/router/types.go
@@ -47,6 +47,8 @@ type Config struct {
 	Port int
 	// The label selector used to identify routable objects
 	RoutableLabelSelector labels.Selector
+	// Max client request body size. nginx config: client_max_body_size. eg 10m
+	ClientMaxBodySize string
 }
 
 /*


### PR DESCRIPTION
Fixes #51 

Defaults to 100mb and can be changed using `CLIENT_MAX_BODY_SIZE` env var.