### PR TITLE
Nginx health check

### DIFF
--- a/router/config.go
+++ b/router/config.go
@@ -37,8 +37,10 @@ const (
 	DefaultAPIKeySecretDataField = "api-key"
 	// DefaultAPIKeySecretLocation is the default value for the EnvVarAPIKeySecretLocation (routing:api-key)
 	DefaultAPIKeySecretLocation = DefaultAPIKeySecret + ":" + DefaultAPIKeySecretDataField
-	// DefaultClientMaxBodySize for nginx max client request size. Default 100mb
+	// DefaultClientMaxBodySize for nginx max client request size. Default no limit
 	DefaultClientMaxBodySize = "0"
+	// DefaultEnableNginxUpstreamCheckModule default disable health check
+	DefaultEnableNginxUpstreamCheckModule = false
 	// DefaultHostsAnnotation is the default value for EnvVarHostsAnnotation (routingHosts)
 	DefaultHostsAnnotation = "routingHosts"
 	// DefaultPathsAnnotation is the default value for the EnvVarHostsAnnotation (routingPaths)
@@ -51,6 +53,8 @@ const (
 	EnvVarAPIKeyHeader = "API_KEY_HEADER"
 	// EnvVarAPIKeySecretLocation Environment variable name for providing the location of the secret (name:field) to identify API Key secrets
 	EnvVarAPIKeySecretLocation = "API_KEY_SECRET_LOCATION"
+	// EnvVarEnableNginxUpstreamCheckModule Environment variable name for enabling nginx upstream check module
+	EnvVarEnableNginxUpstreamCheckModule = "ENABLE_NGINX_UPSTREAM_CHECK"
 	// EnvVarHostsAnnotation Environment variable name for providing the name of the hosts annotation
 	EnvVarHostsAnnotation = "HOSTS_ANNOTATION"
 	// EnvVarPathsAnnotation Environment variable name for providing the the name of the paths annotation
@@ -80,6 +84,7 @@ func ConfigFromEnv() (*Config, error) {
 		HostsAnnotation:   os.Getenv(EnvVarHostsAnnotation),
 		PathsAnnotation:   os.Getenv(EnvVarPathsAnnotation),
 		ClientMaxBodySize: os.Getenv(EnvClientMaxBodySize),
+		EnableNginxUpstreamCheckModule: DefaultEnableNginxUpstreamCheckModule,
 	}
 
 	// Apply defaults
@@ -97,6 +102,14 @@ func ConfigFromEnv() (*Config, error) {
 
 	if config.ClientMaxBodySize == "" {
 		config.ClientMaxBodySize = DefaultClientMaxBodySize
+	}
+
+	// Enable/Disable nginx upstream health check
+	if os.Getenv(EnvVarEnableNginxUpstreamCheckModule) != "" &&
+		os.Getenv(EnvVarEnableNginxUpstreamCheckModule) != "0" {
+		config.EnableNginxUpstreamCheckModule = true
+	} else {
+		config.EnableNginxUpstreamCheckModule = false
 	}
 
 	// Validate configuration

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -59,6 +59,7 @@ func resetEnv(t *testing.T) {
 	unsetEnv(EnvVarPathsAnnotation)
 	unsetEnv(EnvVarPort)
 	unsetEnv(EnvVarRoutableLabelSelector)
+	unsetEnv(EnvVarEnableNginxUpstreamCheckModule)
 }
 
 func setEnv(t *testing.T, key, value string) {
@@ -86,6 +87,8 @@ func validateConfig(t *testing.T, desc string, expected *Config, actual *Config)
 		t.Fatalf(makeError("Port", strconv.Itoa(expected.Port), strconv.Itoa(actual.Port)))
 	} else if expected.RoutableLabelSelector.String() != actual.RoutableLabelSelector.String() {
 		t.Fatalf(makeError("RoutableLabelSelector", expected.RoutableLabelSelector.String(), actual.RoutableLabelSelector.String()))
+	} else if expected.EnableNginxUpstreamCheckModule != actual.EnableNginxUpstreamCheckModule {
+		t.Fatalf("EnableNginxUpstreamCheckModule does not match in config for %s.", desc)
 	}
 }
 
@@ -100,6 +103,7 @@ func TestConfigFromEnvDefaultConfig(t *testing.T) {
 		PathsAnnotation:       DefaultPathsAnnotation,
 		Port:                  DefaultPort,
 		RoutableLabelSelector: getLabelSelector(t, DefaultRoutableLabelSelector),
+		EnableNginxUpstreamCheckModule: DefaultEnableNginxUpstreamCheckModule,
 	})
 }
 

--- a/router/types.go
+++ b/router/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package router
 
 import (
+	"reflect"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -39,6 +41,8 @@ type Config struct {
 	APIKeySecret string
 	// The secret data field name to store the API Key for the namespace
 	APIKeySecretDataField string
+	// Enable Nginx Upstream Health Check Module
+	EnableNginxUpstreamCheckModule bool
 	// The name of the annotation used to find hosts to route
 	HostsAnnotation string
 	// The name of the annotation used to find paths to route
@@ -65,6 +69,25 @@ Outgoing describes the information required to proxy to a backend
 type Outgoing struct {
 	IP   string
 	Port string
+	HealthCheck *HealthCheck
+}
+
+/*
+Health check of an Outgoing upstream server allows nginx to monitor pod health.
+*/
+type HealthCheck struct {
+	HttpCheck bool
+	Path string
+	Method string
+	TimeoutMs int32
+	IntervalMs int32
+	UnhealthyThreshold int32
+	HealthyThreshold int32
+	Port int32
+}
+
+func (a HealthCheck) Equal(b *HealthCheck) bool {
+	return reflect.DeepEqual(a, *b);
 }
 
 /*


### PR DESCRIPTION
Implements changes to router that pulls readiness or liveness probes from the pods and converts them into the required nginx conf for nginx health check module. https://github.com/apigee/nginx_upstream_check_module

Notable changes:
1. Nginx config update based on pod probes.
1. All backends use upstream b/c health checks are only enabled on upstreams.
1. ENV parameter to enable nginx health checks. Off by default.

Todo:
1. Update tests to new config
#55 